### PR TITLE
Update UserPoolTemplate.yaml

### DIFF
--- a/aws/UserPoolTemplate.yaml
+++ b/aws/UserPoolTemplate.yaml
@@ -71,10 +71,7 @@ Resources:
             - logs:CreateLogGroup
             - logs:CreateLogStream
             - logs:PutLogEvents        
-            - xray:PutTraceSegments
-            - xray:PutTelemetryRecords
-            Resource:
-            - "*"
+            Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*:*
             
   DuoKeysSecret:
     Type: 'AWS::SecretsManager::Secret'


### PR DESCRIPTION
fine tune the lambda execution role a bit.

*Issue #, if available:*
CF-NAG warning
| WARN W11
|
| Resource: ["LambdaExecutionRole"]
| Line Numbers: [52]
|
| IAM role should not allow * resource on its permissions policy

*Description of changes:*
Limit lambda role permission to CW lambda loggroups only. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
